### PR TITLE
add support for Rails 3

### DIFF
--- a/lib/portable_contacts.rb
+++ b/lib/portable_contacts.rb
@@ -1,6 +1,6 @@
 require 'uri'
 require 'json'
-require 'activesupport'
+require 'active_support'
 module PortableContacts
   
   # This is the main PortableContacts Client.

--- a/lib/portable_contacts.rb
+++ b/lib/portable_contacts.rb
@@ -1,6 +1,11 @@
 require 'uri'
 require 'json'
-require 'active_support'
+begin
+  require 'active_support' # Rails 3+
+rescue LoadError
+  require 'activesupport' # older versions of Rails
+end
+
 module PortableContacts
   
   # This is the main PortableContacts Client.


### PR DESCRIPTION
The require statement needed for ActiveSupport has changed in Rails 3 - this fix supports this, but falls back for older versions of Rails.
